### PR TITLE
Add Monterey (macOS 12.0+) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ And if you're sensitive to temporal dithering you should notice a lot less eyest
 A more complicated approach is to use a [video capture card](https://www.blackmagicdesign.com/products/ultrastudio/techspecs/W-DLUS-12) and record your display's uncompressed output. You can then process the recorded footage with FFmpeg to visualize dithering using a command like the following:
 
 `ffmpeg -i input.mov -sws_flags full_chroma_int+bitexact+accurate_rnd -vf "format=gbrp,tblend=all_mode=grainextract,eq=contrast=-60" -c:v v210 -pix_fmt yuv422p10le diff.mov`
+
 ## Roadmap
 - Create a foolproof and easy dithering test
 - Intel Macs?

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ To verify that your GPU is not applying dithering you can try a visual test by v
 
 Set your built-in display’s color profile to sRGB at full brightness and look carefully at the gray parts, you should be able to see subtle banding when you disable dithering which happens in real-time.
 
-And if you're sensitive to temporal dithering you should notice a lot less eye strain while dithering is disabled.
+And if you're sensitive to temporal dithering you should notice a lot less eyestrain while dithering is disabled.
 
-A more complicated approach is to use a [video capture card](https://www.blackmagicdesign.com/products/ultrastudio/techspecs/W-DLUS-12) and record your display's uncompressed output. Then run the recording through ffmpeg to visualize dithering with something like the following command: 
+A more complicated approach is to use a [video capture card](https://www.blackmagicdesign.com/products/ultrastudio/techspecs/W-DLUS-12) and record your display's uncompressed output. You can then process the recorded footage with FFmpeg to visualize dithering using a command like the following:
 
 `ffmpeg -i input.mov -sws_flags full_chroma_int+bitexact+accurate_rnd -vf "format=gbrp,tblend=all_mode=grainextract,eq=contrast=-60" -c:v v210 -pix_fmt yuv422p10le diff.mov`
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!NOTE]  
+> This repository is a fork of the awesome [Stillcolor](https://github.com/aiaf/Stillcolor) repository. The primary purpose of this fork is to provide backward compatibility for macOS 12.0+ (Monterey).
+> For macOS 13.0+ (Ventura) and later versions, I highly recommend using the original [Stillcolor](https://github.com/aiaf/Stillcolor) repository.
 
 
 # Stillcolor for macOS
@@ -15,14 +18,14 @@ Save your eyesight and disable temporal dithering on your Mac with Stillcolor, a
 
 These sensitivities manifest as eyestrain and fatigue, dry eyes, headache, nausea, inability to focus, and other physical symptoms.
 
-There's even a [petition](https://www.change.org/p/apple-add-accessibility-options-to-reduce-eye-strain-and-support-vision-disability-sufferers) urging Apple to make use of these technologies known and to implement accessbility options.
+There's even a [petition](https://www.change.org/p/apple-add-accessibility-options-to-reduce-eye-strain-and-support-vision-disability-sufferers) urging Apple to make use of these technologies known and to implement accessibility options.
 
-While there are apps and accessories to help dim blue light, and plenty of flicker-free monitors, temporal dithering can happen at the GPU level with no visible option to disable it (such as the case in Apple silicon Macs).
+While there are apps and accessories to help dim blue light, and plenty of flicker-free monitors, temporal dithering can happen at the GPU level with no visible option to disable it (such as the case in Apple Silicon Macs).
 
-Stillcolor allows you to disable GPU/DCP-generated temporal dithering from user space, helping massively reduce eyestrain with little to no degradation in image quality.
+Stillcolor allows you to disable GPU/DCP-generated temporal dithering from user space, helping massively reduce eye strain with little to no degradation in image quality.
 
 ## Caveats
-Note that while Stillcolor is 100% confirmed to remove GPU/DCP-generated temporal dithering, which is applied directly to the pixel framebuffer right before it's sent to the external/embedded display, the display panel's timing contoller (TCON) may still apply its own dithering/FRC to achieve advertised color bit depth. Whether or not Apple displays actively use TCON dithering in addition to DCP/GPU dithering is under investigation.
+Note that while Stillcolor is 100% confirmed to remove GPU/DCP-generated temporal dithering, which is applied directly to the pixel frame buffer right before it's sent to the external/embedded display, the display panel's timing controller (TCON) may still apply its own dithering/FRC to achieve advertised color bit depth. Whether Apple displays actively use TCON dithering in addition to DCP/GPU dithering is under investigation.
 
 
 ## Story and write-up
@@ -34,8 +37,8 @@ See this timeblend video of how your screen looks like with temporal dithering v
 [https://www.youtube.com/watch?v=D9AZqJH-U-U](https://www.youtube.com/watch?v=D9AZqJH-U-U) 
 
 ## Requirements
-- Apple silicon Mac e.g. M1/M2/M3
-- macOS >= 13
+- Apple Silicon Mac e.g. M1/M2/M3
+- macOS >= 12.0
 
 ## Installation
 Head over to [Releases](https://github.com/aiaf/Stillcolor/releases) and download the latest zip.
@@ -46,7 +49,7 @@ Select “Launch a login” to make this app run automatically and disable dithe
 
 ## Verifying status of temporal dithering
 
-To check wether the app did the job, run the following in Terminal:
+To check whether the app did the job, run the following in Terminal:
 
 `ioreg -lw0 | grep -i enableDither`
 
@@ -58,21 +61,10 @@ To re-enable dithering simply uncheck “Disable Dithering.”
 
 To verify that your GPU is not applying dithering you can try a visual test by visiting [Lagom LCD Gradient (banding) test](http://www.lagom.nl/lcd-test/gradient.php) 
 
-Set your built-in display’s color profile to sRGB at full brightness and look carefully at the gray parts, you should be able to see subtle banding when you disable dithering which happens in realtime.
+Set your built-in display’s color profile to sRGB at full brightness and look carefully at the gray parts, you should be able to see subtle banding when you disable dithering which happens in real-time.
 
-And if you're sensitive to temporal dithering you should notice a lot less eyestrain while dithering is disabled.
+And if you're sensitive to temporal dithering you should notice a lot less eye strain while dithering is disabled.
 
-A more complicated approach is to use a [video capture card](https://www.blackmagicdesign.com/products/ultrastudio/techspecs/W-DLUS-12) and record your display's uncompressed output then run the recording through ffmpeg to visualize dithering with something like the following command: 
+A more complicated approach is to use a [video capture card](https://www.blackmagicdesign.com/products/ultrastudio/techspecs/W-DLUS-12) and record your display's uncompressed output. Then run the recording through ffmpeg to visualize dithering with something like the following command: 
 
 `ffmpeg -i input.mov -sws_flags full_chroma_int+bitexact+accurate_rnd -vf "format=gbrp,tblend=all_mode=grainextract,eq=contrast=-60" -c:v v210 -pix_fmt yuv422p10le diff.mov`
-
-## Roadmap
-- Make this app compatible macOS 11+
-- Create a foolproof and easy dithering test
-- Intel Macs?
-- iOS?
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-> [!NOTE]  
-> This repository is a fork of the awesome [Stillcolor](https://github.com/aiaf/Stillcolor) repository. The primary purpose of this fork is to provide backward compatibility for macOS 12.0+ (Monterey).
-> For macOS 13.0+ (Ventura) and later versions, I highly recommend using the original [Stillcolor](https://github.com/aiaf/Stillcolor) repository.
-
-
 # Stillcolor for macOS
 <img src="https://github.com/aiaf/Stillcolor/assets/119462/26f4fe39-44bb-436d-9348-fc5ba9e8dfde" align=left width=256>
 Save your eyesight and disable temporal dithering on your Mac with Stillcolor, a lightweight menu bar app for macOS running on Apple M1/M2/M3.  
@@ -22,10 +17,10 @@ There's even a [petition](https://www.change.org/p/apple-add-accessibility-optio
 
 While there are apps and accessories to help dim blue light, and plenty of flicker-free monitors, temporal dithering can happen at the GPU level with no visible option to disable it (such as the case in Apple Silicon Macs).
 
-Stillcolor allows you to disable GPU/DCP-generated temporal dithering from user space, helping massively reduce eye strain with little to no degradation in image quality.
+Stillcolor allows you to disable GPU/DCP-generated temporal dithering from user space, helping massively reduce eyestrain with little to no degradation in image quality.
 
 ## Caveats
-Note that while Stillcolor is 100% confirmed to remove GPU/DCP-generated temporal dithering, which is applied directly to the pixel frame buffer right before it's sent to the external/embedded display, the display panel's timing controller (TCON) may still apply its own dithering/FRC to achieve advertised color bit depth. Whether Apple displays actively use TCON dithering in addition to DCP/GPU dithering is under investigation.
+Note that while Stillcolor is 100% confirmed to remove GPU/DCP-generated temporal dithering, which is applied directly to the pixel framebuffer right before it's sent to the external/embedded display, the display panel's timing controller (TCON) may still apply its own dithering/FRC to achieve advertised color bit depth. Whether Apple displays actively use TCON dithering in addition to DCP/GPU dithering is under investigation.
 
 
 ## Story and write-up
@@ -68,3 +63,12 @@ And if you're sensitive to temporal dithering you should notice a lot less eye s
 A more complicated approach is to use a [video capture card](https://www.blackmagicdesign.com/products/ultrastudio/techspecs/W-DLUS-12) and record your display's uncompressed output. Then run the recording through ffmpeg to visualize dithering with something like the following command: 
 
 `ffmpeg -i input.mov -sws_flags full_chroma_int+bitexact+accurate_rnd -vf "format=gbrp,tblend=all_mode=grainextract,eq=contrast=-60" -c:v v210 -pix_fmt yuv422p10le diff.mov`
+## Roadmap
+- Create a foolproof and easy dithering test
+- Intel Macs?
+- iOS?
+
+
+
+
+

--- a/Stillcolor.xcodeproj/project.pbxproj
+++ b/Stillcolor.xcodeproj/project.pbxproj
@@ -3,14 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2DB2FB672C92383600158943 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 2DB2FB662C92383600158943 /* LaunchAtLogin */; };
 		384543E92BB5F0EB00E9C709 /* IORegistryPropertyHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384543E82BB5F0EB00E9C709 /* IORegistryPropertyHelper.swift */; };
 		3865859A2B8B55CC00812B02 /* StillcolorApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386585992B8B55CC00812B02 /* StillcolorApp.swift */; };
 		3865859E2B8B55CD00812B02 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3865859D2B8B55CD00812B02 /* Assets.xcassets */; };
-		386585C62B8B8A1F00812B02 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 386585C52B8B8A1F00812B02 /* LaunchAtLogin */; };
 		386585C82B8BF53300812B02 /* Stillcolor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386585C72B8BF53300812B02 /* Stillcolor.swift */; };
 		386585CA2B8BF5AC00812B02 /* ScreenDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386585C92B8BF5AC00812B02 /* ScreenDetector.swift */; };
 /* End PBXBuildFile section */
@@ -43,7 +43,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				386585C62B8B8A1F00812B02 /* LaunchAtLogin in Frameworks */,
+				2DB2FB672C92383600158943 /* LaunchAtLogin in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,6 +98,7 @@
 				386585922B8B55CC00812B02 /* Sources */,
 				386585932B8B55CC00812B02 /* Frameworks */,
 				386585942B8B55CC00812B02 /* Resources */,
+				2D1CAE382C922F0700B84AA6 /* Launch at Login Helper */,
 				386585BF2B8B880D00812B02 /* CopyFiles */,
 			);
 			buildRules = (
@@ -106,7 +107,7 @@
 			);
 			name = Stillcolor;
 			packageProductDependencies = (
-				386585C52B8B8A1F00812B02 /* LaunchAtLogin */,
+				2DB2FB662C92383600158943 /* LaunchAtLogin */,
 			);
 			productName = HonestColor;
 			productReference = 386585962B8B55CC00812B02 /* Stillcolor.app */;
@@ -129,7 +130,7 @@
 				};
 			};
 			buildConfigurationList = 386585912B8B55CC00812B02 /* Build configuration list for PBXProject "Stillcolor" */;
-			compatibilityVersion = "Xcode 14.0";
+			compatibilityVersion = "Xcode 15.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -138,7 +139,7 @@
 			);
 			mainGroup = 3865858D2B8B55CC00812B02;
 			packageReferences = (
-				386585C42B8B8A1F00812B02 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
+				2DB2FB652C92383600158943 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Legacy" */,
 			);
 			productRefGroup = 386585972B8B55CC00812B02 /* Products */;
 			projectDirPath = "";
@@ -159,6 +160,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2D1CAE382C922F0700B84AA6 /* Launch at Login Helper */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Launch at Login Helper";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${BUILT_PRODUCTS_DIR}/LaunchAtLogin_LaunchAtLogin.bundle/Contents/Resources/copy-helper-swiftpm.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		386585922B8B55CC00812B02 /* Sources */ = {
@@ -212,7 +235,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -228,7 +251,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -275,7 +298,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -285,7 +308,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -309,6 +332,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Stillcolor;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
@@ -318,7 +342,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.makkuk.Stillcolor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -346,6 +370,7 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Stillcolor;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
@@ -355,7 +380,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.makkuk.Stillcolor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -390,9 +415,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		386585C42B8B8A1F00812B02 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */ = {
+		2DB2FB652C92383600158943 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Legacy" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin-Modern";
+			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin-Legacy";
 			requirement = {
 				branch = main;
 				kind = branch;
@@ -401,9 +426,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		386585C52B8B8A1F00812B02 /* LaunchAtLogin */ = {
+		2DB2FB662C92383600158943 /* LaunchAtLogin */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 386585C42B8B8A1F00812B02 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
+			package = 2DB2FB652C92383600158943 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Legacy" */;
 			productName = LaunchAtLogin;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Stillcolor.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Stillcolor.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Stillcolor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stillcolor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "launchatlogin-modern",
+      "identity" : "launchatlogin-legacy",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sindresorhus/LaunchAtLogin-Modern",
+      "location" : "https://github.com/sindresorhus/LaunchAtLogin-Legacy",
       "state" : {
         "branch" : "main",
-        "revision" : "a04ec1c363be3627734f6dad757d82f5d4fa8fcc"
+        "revision" : "9a894d799269cb591037f9f9cb0961510d4dca81"
       }
     }
   ],

--- a/Stillcolor/ScreenDetector.swift
+++ b/Stillcolor/ScreenDetector.swift
@@ -32,7 +32,7 @@ class ScreenDetector {
     }
     
 
-    func addObervers() {
+    func addObservers() {
         let userData = Unmanaged<ScreenDetector>.passUnretained(self).toOpaque()
         CGDisplayRegisterReconfigurationCallback(ScreenDetector.callback, userData)
     }

--- a/Stillcolor/StillcolorApp.swift
+++ b/Stillcolor/StillcolorApp.swift
@@ -3,6 +3,7 @@
 //  Stillcolor
 //
 //  Created by Abdullah Arif on 25/02/2024.
+//  Modified by GMMDMDIDEMS on 12/09/2024.
 //
 
 import SwiftUI
@@ -14,49 +15,89 @@ struct StillcolorApp: App {
     @AppStorage("disableUniformity2D") var disableUniformity2D: Bool = false
     
     var detector = ScreenDetector();
+    var statusBarItem: NSStatusItem?
+    
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
-        detector.addObervers()
+        detector.addObservers()
         Stillcolor.enableDisableDithering(disableDithering)
         Stillcolor.enableDisableUniformity2D(disableUniformity2D)
     }
     
     var body: some Scene {
-        MenuBarExtra(
-            "Stillcolor",
-            systemImage: "\(disableDithering  ? "livephoto.slash" : "livephoto")"
-        ) {
-            Toggle("Disable Dithering", isOn: .init(
-                get: { disableDithering },
-                set: {
-                    disableDithering = $0
-                    Stillcolor.enableDisableDithering(disableDithering)
-                }
-            ))
-            
-            Toggle("Disable uniformity2D", isOn: .init(
-                get: { disableUniformity2D },
-                set: {
-                    disableUniformity2D = $0
-                    Stillcolor.enableDisableUniformity2D(disableUniformity2D)
-                }
-            ))
-            
-            Label {
-                Text("(Experimental) Stop built-in display from\nusing lower brightness levels around the edges")
-                    .font(.caption)
-                    .fontWeight(.thin)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.leading)
-            } icon: {
-            }
-            
-            Divider()
-            LaunchAtLogin.Toggle()
-            Divider()
-            Button("Quit Stillcolor") {
-                NSApplication.shared.terminate(nil)
-            }.keyboardShortcut("q")
+        Settings{
+            EmptyView()
         }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    @AppStorage("disableDithering") var disableDithering: Bool = true
+
+    var statusItem: NSStatusItem?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        if let button = statusItem?.button {
+            button.image = NSImage(systemSymbolName: disableDithering ? "livephoto.slash" : "livephoto", accessibilityDescription: nil)
+        }
+
+        constructMenu()
+    }
+
+    private func constructMenu() {
+        let menu = NSMenu()
+
+        let menuItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        let hostingView = NSHostingController(rootView: MenuView())
+        hostingView.view.frame = NSRect(x: 0, y: 0, width: 300, height: 125)
+        menuItem.view = hostingView.view
+
+        menu.addItem(menuItem)
+        menu.addItem(NSMenuItem.separator())
+        menu.addItem(NSMenuItem(title: "Quit Stillcolor", action: #selector(quit), keyEquivalent: "q"))
+
+        statusItem?.menu = menu
+    }
+
+    @objc func quit() {
+        NSApplication.shared.terminate(self)
+    }
+}
+
+struct MenuView: View {
+    @AppStorage("disableDithering") var disableDithering: Bool = true
+    @AppStorage("disableUniformity2D") var disableUniformity2D: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle(isOn: $disableDithering) {
+                Text("Disable Dithering")
+            }
+            .onChange(of: disableDithering) { newValue in
+                Stillcolor.enableDisableDithering(newValue)
+            }
+
+            Toggle(isOn: $disableUniformity2D) {
+                Text("Disable uniformity2D")
+            }
+            .onChange(of: disableUniformity2D) { newValue in
+                Stillcolor.enableDisableUniformity2D(newValue)
+            }
+
+            Text("(Experimental) Stop built-in display from using lower brightness levels around the edges")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.leading, 20)
+
+            Divider()
+
+            LaunchAtLogin.Toggle()
+        }
+        .padding()
+        .frame(width: 300)
     }
 }

--- a/Stillcolor/StillcolorApp.swift
+++ b/Stillcolor/StillcolorApp.swift
@@ -9,92 +9,121 @@
 import SwiftUI
 import LaunchAtLogin
 
+// Delegate protocol to update menu bar icon
+// https://developer.apple.com/documentation/swift/using-delegates-to-customize-object-behavior
+protocol AppStateDelegate: AnyObject {
+    func updateStatusItemImage()
+}
+
+// Singleton for managing application-wide state
+// https://developer.apple.com/documentation/swift/managing-a-shared-resource-using-a-singleton
+class AppState: ObservableObject {
+    static let shared = AppState()
+    
+    @Published var disableDithering: Bool {
+        didSet {
+            UserDefaults.standard.set(disableDithering, forKey: "disableDithering")
+            Stillcolor.enableDisableDithering(disableDithering)
+            // Update menu bar icon
+            delegate?.updateStatusItemImage()
+        }
+    }
+    
+    @Published var disableUniformity2D: Bool {
+        didSet {
+            UserDefaults.standard.set(disableUniformity2D, forKey: "disableUniformity2D")
+            Stillcolor.enableDisableUniformity2D(disableUniformity2D)
+        }
+    }
+    
+    weak var delegate: AppStateDelegate?
+    
+    private init() {
+        self.disableDithering = UserDefaults.standard.bool(forKey: "disableDithering")
+        self.disableUniformity2D = UserDefaults.standard.bool(forKey: "disableUniformity2D")
+    }
+}
+
 @main
 struct StillcolorApp: App {
-    @AppStorage("disableDithering") var disableDithering: Bool = true
-    @AppStorage("disableUniformity2D") var disableUniformity2D: Bool = false
-    
-    var detector = ScreenDetector();
-    var statusBarItem: NSStatusItem?
+    var detector = ScreenDetector()
     
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
         detector.addObservers()
-        Stillcolor.enableDisableDithering(disableDithering)
-        Stillcolor.enableDisableUniformity2D(disableUniformity2D)
+        Stillcolor.enableDisableDithering(AppState.shared.disableDithering)
+        Stillcolor.enableDisableUniformity2D(AppState.shared.disableUniformity2D)
+        AppState.shared.delegate = appDelegate
     }
     
     var body: some Scene {
-        Settings{
+        Settings {
             EmptyView()
         }
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate {
-    @AppStorage("disableDithering") var disableDithering: Bool = true
-
+// https://developer.apple.com/documentation/swift/using-delegates-to-customize-object-behavior
+class AppDelegate: NSObject, NSApplicationDelegate, AppStateDelegate {
     var statusItem: NSStatusItem?
-
+    
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-
-        if let button = statusItem?.button {
-            button.image = NSImage(systemSymbolName: disableDithering ? "livephoto.slash" : "livephoto", accessibilityDescription: nil)
-        }
-
+        updateStatusItemImage()
         constructMenu()
     }
-
+    
+    func updateStatusItemImage() {
+        if let button = statusItem?.button {
+            let imageName = AppState.shared.disableDithering ? "livephoto.slash" : "livephoto"
+            button.image = NSImage(systemSymbolName: imageName, accessibilityDescription: nil)
+        }
+    }
+    
     private func constructMenu() {
         let menu = NSMenu()
-
-        let menuItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        
+        let menuItem = NSMenuItem()
         let hostingView = NSHostingController(rootView: MenuView())
-        hostingView.view.frame = NSRect(x: 0, y: 0, width: 300, height: 125)
+        // Change width to 295 to improve item alignment
+        hostingView.view.frame = NSRect(x: 0, y: 0, width: 295, height: 110)
         menuItem.view = hostingView.view
-
+        
         menu.addItem(menuItem)
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Quit Stillcolor", action: #selector(quit), keyEquivalent: "q"))
-
+        
         statusItem?.menu = menu
     }
-
+    
     @objc func quit() {
         NSApplication.shared.terminate(self)
     }
 }
 
 struct MenuView: View {
-    @AppStorage("disableDithering") var disableDithering: Bool = true
-    @AppStorage("disableUniformity2D") var disableUniformity2D: Bool = false
+    @ObservedObject var appState = AppState.shared
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Toggle(isOn: $disableDithering) {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: $appState.disableDithering) {
                 Text("Disable Dithering")
             }
-            .onChange(of: disableDithering) { newValue in
-                Stillcolor.enableDisableDithering(newValue)
+            
+            Toggle(isOn: $appState.disableUniformity2D) {
+                Text("Disable Uniformity2D")
             }
-
-            Toggle(isOn: $disableUniformity2D) {
-                Text("Disable uniformity2D")
-            }
-            .onChange(of: disableUniformity2D) { newValue in
-                Stillcolor.enableDisableUniformity2D(newValue)
-            }
-
+            
             Text("(Experimental) Stop built-in display from using lower brightness levels around the edges")
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, -6) // reduce vertical space
                 .padding(.leading, 20)
-
+            
             Divider()
-
+            
             LaunchAtLogin.Toggle()
         }
         .padding()


### PR DESCRIPTION
Fixes https://github.com/aiaf/Stillcolor/issues/7
To add macOS 12.0+ support, I had to:
- Downgrade `LaunchAtLogin` support for macOS 12 following the official guide [here](https://github.com/sindresorhus/LaunchAtLogin-Legacy). This step also increases app size due to the package bundling.
- Replace `MenuBarExtra` as it is only supported since macOS 13

This is my first time working with Swift, so I had some challenges identifying the predecessor to `MenuBarExtra`. Even though my current approach is compatible with macOS 12, there may be more effective methods for creating menu bar applications on macOS 12. 

However, for macOS 13+ I definitely recommend using your implementation.